### PR TITLE
added cache for build file. clean up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,28 +26,34 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo apt-key fingerprint 0EBFCD88
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-          sudo apt-get update
-          sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-          sudo docker pull wiidiiremi/projet_industrialisation_ia_3a
+          pip install -r requirements.txt
 
-          python -m pip install --upgrade pip
-          pip install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install docker
+        run: |
+          chmod +x ./scripts/get_docker.sh
+          bash ./scripts/get_docker.sh
+
       - name: Lint with flake8
         run: |
           # The GitHub editor is 127 chars wide
           flake8 . --count --max-line-length=127 --statistics
-      # Runs a single command using the runners shell
+
       - name: Test with pytest
         run: |
-          sudo docker run -d -p 8080:8080 wiidiiremi/projet_industrialisation_ia_3a
-          chmod +x ./scripts/wait_service.sh
-          bash ./scripts/wait_service.sh
+          chmod +x ./scripts/start_service.sh
+          bash ./scripts/start_service.sh
           python -m pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 numpy==1.18.5
 requests==2.24.0
 scikit-learn==0.23.2
+flake8==3.8.3
+pytest==5.4.3

--- a/scripts/get_docker.sh
+++ b/scripts/get_docker.sh
@@ -1,0 +1,8 @@
+sudo apt-get update
+sudo apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo apt-key fingerprint 0EBFCD88
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo apt-get update
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+sudo docker pull wiidiiremi/projet_industrialisation_ia_3a

--- a/scripts/start_service.sh
+++ b/scripts/start_service.sh
@@ -1,3 +1,5 @@
+sudo docker run -d -p 8080:8080 wiidiiremi/projet_industrialisation_ia_3a
+
 res=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n'  http://localhost:8080/api/intent?sentence=trouve%20des%20toilette ])
 max_attempts=50
 attempts=1


### PR DESCRIPTION
This solves issue #20  . We cache all files in `requirements.txt`, which means that everytime we update our requirements file (which should not be that often) build time will be slow only the first time.

With cache hit time for tests to run when from ~13minutes to ~3minutes, which I think it's an acceptable time. 

Most of the time for tests to run come from:
 - Downloading and installing docker (around 1minute): can possibly be improved with cache too, but I'm not sure it's necessary
 - Getting the service up (around ~25s): hard to improve